### PR TITLE
Separate build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ yarn add @stevent-team/epoxy
 
 You can also run `npx epoxy --help` to see this information.
 
+#### `epoxy serve` or `epoxy`
+
 ```
 epoxy <target> [routeFile] [options]
 
 target     Path to static directory
-routeFile  Path to router script
+routeFile  Path to cjs router script (can use ES6 with --build option)
 
 Options:
       --help     Show help                                                     [boolean]
@@ -31,6 +33,20 @@ Options:
   -p, --port     port to use for http server                    [string] [default: 8080]
   -h, --host     host to use for http server               [string] [default: "0.0.0.0"]
   -i, --index    path to index html inside of target    [string] [default: "index.html"]
+  -b, --build    build routes file in memory                  [boolean] [default: false]
+```
+
+#### `epoxy build`
+
+```
+epoxy build <routeFile>
+
+routeFile  Path to ES6 router script
+
+Options:
+      --help       Show help                                                 [boolean]
+      --version    Show version number                                       [boolean]
+  -o, --outputDir  folder to output built routes file       [string] [default: "dist"]
 ```
 
 ## Example
@@ -84,19 +100,33 @@ export default {
 Then serve your static directory and dynamic routes!
 
 ```bash
-epoxy ./dist ./routes.js
+epoxy ./dist ./routes.js --build
 ```
 
 or setup an npm script
 
-```js
+```json
 // package.json
 {
   "scripts": {
-    "serve": "epoxy ./dist ./routes.js"
+    "serve": "epoxy ./dist ./routes.js --build"
   }
 }
 ```
+
+If you have a deployment that will need to start and stop your Epoxy server often, such as an automatically scaled deployment like Google App Engine, then you can prebuild the routes file so it doesn't have to build before every start:
+
+```json
+// package.json
+{
+  "scripts": {
+    "build": "epoxy ./routes.js",
+    "serve": "epoxy ./dist ./dist/routes.js"
+  }
+}
+```
+
+Alternatively, you could also write your routes file in CommonJS so it doesn't require building.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ If you have a deployment that will need to start and stop your Epoxy server ofte
 // package.json
 {
   "scripts": {
-    "build": "epoxy ./routes.js",
+    "build": "epoxy build ./routes.js",
     "serve": "epoxy ./dist ./dist/routes.js"
   }
 }
 ```
 
-Alternatively, you could also write your routes file in CommonJS so it doesn't require building.
+Alternatively, you could also write your routes file in CommonJS so it doesn't require building; the `epoxy serve` command only build if the flag `--build` is specified.
 
 ## API
 

--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
 import yargs from 'yargs'
 import path from 'path'
+import { Parcel } from '@parcel/core'
 
 import loadRoutes from './src/loadRoutes'
 import startServer, { Routes } from './src/server'
 
-const serve = async ({ target, routeFile, host, port, index }) => {
+const serve = async ({ target, routeFile, host, port, index, build }) => {
   // Load routes
   let routes: Routes = {}
   if (routeFile) {
     const resolvedRoutes = path.resolve(routeFile)
-    routes = await loadRoutes(resolvedRoutes).catch(e => {
+    routes = await loadRoutes(resolvedRoutes, build).catch(e => {
       throw new Error(`Failed to load routes file "${resolvedRoutes}": ${e}`)
     })
   }
@@ -32,6 +33,31 @@ const serve = async ({ target, routeFile, host, port, index }) => {
   })
 }
 
+const build = async ({ routeFile, outputDir }) => {
+  // Setup bundler
+  const bundler = new Parcel({
+    entries: routeFile,
+    defaultConfig: '@parcel/config-default',
+    mode: 'production',
+    shouldDisableCache: true,
+    targets: {
+      'main': {
+        context: 'node',
+        distDir: outputDir,
+        engines: {
+          node: ">=10"
+        },
+        scopeHoist: false,
+        optimize: false,
+      }
+    }
+  })
+
+  // Build routes configuration
+  const { buildTime } = await bundler.run()
+  console.log(`✨ Built routes file in ${buildTime}ms`)
+}
+
 // Use yargs to parse command line options
 yargs
   .scriptName("epoxy")
@@ -41,25 +67,44 @@ yargs
     'Serve the provided static folder',
     yargs => yargs
       .positional('target', { describe: 'Path to static directory', require: true })
-      .positional('routeFile', { describe: 'Path to router script' }),
+      .positional('routeFile', { describe: 'Path to cjs router script (can use ES6 with --build option)' })
+      .option('port', {
+        alias: 'p',
+        type: 'string',
+        description: 'port to use for http server',
+        default: 8080,
+      })
+      .option('host', {
+        alias: 'h',
+        type: 'string',
+        description: 'host to use for http server',
+        default: '0.0.0.0',
+      })
+      .option('index', {
+        alias: 'i',
+        type: 'string',
+        description: 'path to index html inside of target',
+        default: 'index.html',
+      })
+      .option('build', {
+        alias: 'b',
+        type: 'boolean',
+        description: 'build routes file in memory',
+        default: false,
+      }),
     serve
   )
-  .option('port', {
-    alias: 'p',
-    type: 'string',
-    description: 'port to use for http server',
-    default: 8080,
-  })
-  .option('host', {
-    alias: 'h',
-    type: 'string',
-    description: 'host to use for http server',
-    default: '0.0.0.0',
-  })
-  .option('index', {
-    alias: 'i',
-    type: 'string',
-    description: 'path to index html inside of target',
-    default: 'index.html',
-  })
+  .command(
+    'build <routeFile>',
+    'Build a routes file',
+    yargs => yargs
+      .positional('routeFile', { describe: 'Path to ES6 router script', require: true })
+      .option('outputDir', {
+        alias: 'o',
+        type: 'string',
+        description: 'folder to output built routes file',
+        default: 'dist',
+      }),
+    build
+  )
   .argv

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stevent-team/epoxy",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Lightweight server-side per-route html injection",
   "keywords": [
     "epoxy",

--- a/src/loadRoutes.ts
+++ b/src/loadRoutes.ts
@@ -3,7 +3,14 @@ import { MemoryFS } from '@parcel/fs'
 import requireFromString from 'require-from-string'
 
 // Compile the routes file, then import it
-const loadRoutes = async (routeFile: string) => {
+const loadRoutes = async (routeFile: string, build: boolean) => {
+  // Just import a cjs file
+  if (!build) {
+    console.log(`🎁 Using route file "${routeFile}"`)
+    const module = await import(routeFile)
+    return module.default?.default ?? module.default
+  }
+
   // Setup bundler using memory file system
   const workerFarm = createWorkerFarm()
   const outputFS = new MemoryFS(workerFarm)
@@ -29,7 +36,7 @@ const loadRoutes = async (routeFile: string) => {
 
   // Build routes configuration
   const { bundleGraph, buildTime } = await bundler.run()
-  console.log(`✨ Built routes file in ${buildTime}ms`)
+  console.log(`✨ Built routes file to memory in ${buildTime}ms`)
 
   const [bundle] = bundleGraph.getBundles()
 


### PR DESCRIPTION
Closes #10 

This PR creates a separate build command for building ES6 Epoxy route files, and introduces a breaking change that requires the `--build` flag on the `serve` command to enable in-memory building. As such, this PR bumps the version to 2.0.0