### PR TITLE
Escape HTML special chars from content of meta tags

### DIFF
--- a/helpers/src/createMeta.ts
+++ b/helpers/src/createMeta.ts
@@ -3,10 +3,17 @@ type MetaTags = {
 }
 
 const createMeta = (metaTags: MetaTags): string =>
-  Object.entries(metaTags)
-  .reduce((html, [property, content]) =>
-    (property && content) ? `${html}<meta property="${property}" content="${content}">` : html,
-    ''
-  )
+  Object.entries(metaTags).reduce((html, [property, content]) => {
+    if (!(property && content)) return html // Skip if unset
+
+    // Escape html entities
+    const escapedContent = content
+      .replace(/"/g, "&quot;")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+
+    return `${html}<meta property="${property}" content="${escapedContent}">`
+  }, '')
 
 export default createMeta


### PR DESCRIPTION
Previously, using the `createMeta` helper function would break the HTML if a content value was provided containing a HTML reserved character (`", &, <, >`). This PR replaces them with their HTML entity codes (e.g. `&quot;`) to allow these characters to be used.